### PR TITLE
Add skipPreviousResponseId to config

### DIFF
--- a/src/Conversation.swift
+++ b/src/Conversation.swift
@@ -30,6 +30,7 @@ import Foundation
 
 	/// The last response ID in the conversation.
 	@MainActor public var previousResponseId: String? {
+		guard !config.skipPreviousResponseId else { return nil }
 		guard let entry = entries.last(where: { entry in
 			if case .response = entry { return true }
 			return false
@@ -367,6 +368,9 @@ public extension Conversation {
 
 		/// Inserts a system (or developer) message as the first item in the model's context.
 		public var instructions: String?
+
+		/// Whether to skip the previous response ID.
+		public var skipPreviousResponseId: Bool = false
 
 		/// An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).
 		public var maxOutputTokens: UInt?


### PR DESCRIPTION
Some orgs don't allow data retention on server, so using previousResponseId will throw an error.

Is `skipPreviousResponseId` the right name for this, maybe not... maybe `disablePreviousResponseId`?

Thanks for this library, I look forward to helping improve and fix it... if you need help with any features let me know.