### PR TITLE
 Fixing bug with json serialization on function_call_output

### DIFF
--- a/src/Models/Item.swift
+++ b/src/Models/Item.swift
@@ -47,6 +47,7 @@ public enum Item: Equatable, Hashable, Sendable {
 		case functionCall(Item.FunctionCall)
 
 		/// The output of a function tool call.
+		@CodedAs("function_call_output")
 		case functionCallOutput(Item.FunctionCallOutput)
 
 		/// A description of the chain of thought used by a reasoning model while generating a response.


### PR DESCRIPTION
# Fixing bug with json serialization on function_call_output


We're experiencing a JSON serialization bug when sending function call output responses to the OpenAI API:
`wait conversation.send(functionCallOutput: .init(callId: callId, output: "{ ... }"))
`
The error message indicates that the OpenAI is receiving an invalid value type:

`Failed to send message: Error(type: "invalid_request_error", message: "Invalid value: 'functioncalloutput'. Supported values are: 'computer_call', 'computer_call_output', 'file_search_call', 'function_call', 'function_call_output', 'item_reference', 'message', 'reasoning', and 'web_search_call'.", code: Optional("invalid_value"), param: Optional("input[0]"))`

Upon inspection of Item.swift, I discovered that while most enum cases in Item.Input have the @CodedAs annotation to properly serialize them as snake_case for the API, the functionCall case is missing this annotation. This causes it to be serialized as "functioncalloutput" instead of the required "function_call_output".

To fix this i've added the missing @CodedAs annotation to the functionCall case in Item.Input enum. After switching my app to use the forked version of the package function call outputs are now correctly serialized and accepted by the OpenAI API.

`wait conversation.send(functionCallOutput: .init(callId: callId, output: "{ ... }"))`
