### PR TITLE
Fixing type Error on Temperature Value

### DIFF
--- a/src/Conversation.swift
+++ b/src/Conversation.swift
@@ -395,7 +395,7 @@ public extension Conversation {
 		/// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
 		///
 		/// We generally recommend altering this or `top_p` but not both.
-		public var temperature: Int?
+		public var temperature: Double?
 
 		/// Configuration options for a text response from the model. Can be plain text or structured JSON data.
 		///
@@ -480,7 +480,7 @@ public extension Conversation {
 	/// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
 	///
 	/// We generally recommend altering this or `top_p` but not both.
-	@MainActor var temperature: Int? {
+	@MainActor var temperature: Double? {
 		get { config.temperature }
 		set { config.temperature = newValue }
 	}

--- a/src/Models/Item.swift
+++ b/src/Models/Item.swift
@@ -47,6 +47,7 @@ public enum Item: Equatable, Hashable, Sendable {
 		case functionCall(Item.FunctionCall)
 
 		/// The output of a function tool call.
+		@CodedAs("function_call_output")
 		case functionCallOutput(Item.FunctionCallOutput)
 
 		/// A description of the chain of thought used by a reasoning model while generating a response.

--- a/src/Models/Request.swift
+++ b/src/Models/Request.swift
@@ -62,7 +62,7 @@ import MetaCodable
 	/// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
 	///
 	/// We generally recommend altering this or `top_p` but not both.
-	public var temperature: Int?
+	public var temperature: Double?
 
 	/// Configuration options for a text response from the model. Can be plain text or structured JSON data.
 	/// - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
@@ -125,7 +125,7 @@ import MetaCodable
 		reasoning: ReasoningConfig? = nil,
 		store: Bool? = nil,
 		stream: Bool? = nil,
-		temperature: Int? = nil,
+		temperature: Double? = nil,
 		text: TextConfig? = nil,
 		toolChoice: Tool.Choice? = nil,
 		tools: [Tool]? = nil,

--- a/src/Models/Response.swift
+++ b/src/Models/Response.swift
@@ -169,7 +169,7 @@ import HelperCoders
 	/// Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
 	///
 	/// We generally recommend altering this or `topP` but not both.
-	public var temperature: Int
+	public var temperature: Double
 
 	/// Configuration options for a text response from the model. Can be plain text or structured JSON data.
 	/// - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
@@ -259,7 +259,7 @@ import HelperCoders
 		previousResponseId: String? = nil,
 		reasoning: ReasoningConfig,
 		status: Status,
-		temperature: Int,
+		temperature: Double,
 		text: TextConfig,
 		toolChoice: Tool.Choice,
 		tools: [Tool] = [],


### PR DESCRIPTION
# Fixing type Error on Temperature Value

We were seeing a type mismatch error when attempting to set the temperature value for OpenAI requests:
```swift
config.temperature = 0.5
``` 
The error indicated that Swift couldn’t assign a Double (0.5) to an Int?:

```swift
Cannot assign value of type 'Double' to type 'Int?'
``` 

On inspecting the config struct, I found that temperature was typed as Int?, even though:
- The inline documentation correctly states it should be a value between 0 and 2 (i.e. a floating point range).
- OpenAI's API expects a float for temperature, not an integer.

To resolve this, I updated the property type from Int? to Double?:

```swift
// Before
public var temperature: Int?

// After
public var temperature: Double?
``` 

After making this change, setting fractional temperature values like 0.5 or 0.8 now works correctly without type errors, and the requests to the OpenAI API reflect the intended configuration.