### PR TITLE
Add .swiftformat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,6 @@
+--disable all
+--enable indent
+
+--indent tab
+--indentcase true
+--indentstrings false


### PR DESCRIPTION
If you want to remove the --disable all and run `swiftformat .` on the codebase, that would standardize the format of all the source files.