### PR TITLE
Add id to message input

### DIFF
--- a/src/Models/Message.swift
+++ b/src/Models/Message.swift
@@ -35,6 +35,9 @@ public enum Message: Equatable, Hashable, Sendable {
 	public struct Input: Equatable, Hashable, Codable, Sendable {
 		/// The role of the message input.
 		public var role: Role
+        
+        /// The unique ID of the output message.
+        public var id: String
 
 		/// The status of the message. Populated when the message is returned via API.
 		public var status: Status?
@@ -49,6 +52,7 @@ public enum Message: Equatable, Hashable, Sendable {
 
 		public init(role: Role = .user, content: ModelInput.Content, status: Status? = nil) {
 			self.role = role
+            self.id = UUID().uuidString
 			self.status = status
 			self.content = content
 		}
@@ -120,9 +124,9 @@ public enum Message: Equatable, Hashable, Sendable {
 	}
 
 	/// The unique ID of the message, if available.
-	public var id: String? {
+	public var id: String {
 		switch self {
-			case .input: nil
+            case let .input(input): input.id
 			case let .output(output): output.id
 		}
 	}


### PR DESCRIPTION
Instances of Message didn’t previously have an id when their type was .input.
This could cause issues in SwiftUI’s List when multiple identical input messages appeared (e.g. for example, if a user repeatedly sent "why?" or "explain")

This PR assigns a unique id to Message instances of type .input, ensuring SwiftUI can reliably differentiate between them and render lists correctly.